### PR TITLE
Encoding Options added

### DIFF
--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -44,6 +44,7 @@ class Job < ActiveRecord::Base
                 destination_file: options['output'],
                 preset: Preset.find_by_name(options['preset']),
                 priority: options['priority'],
+                encoding_arguments: options['encoding_arguments'],
                 notifications: Notification.from_api(options[:notify]),
                 arguments: args)
 

--- a/app/models/transcoder.rb
+++ b/app/models/transcoder.rb
@@ -22,7 +22,7 @@ class Transcoder
       {
         'source_file' => job.source_file,
         'destination_file' => job.destination_file,
-        'encoder_options' => job.preset.parameters,
+        'encoder_options' => "#{job.preset.parameters} #{job.encoding_arguments}",
         'thumbnail_options' => thumb_opts
       }
     end

--- a/app/views/jobs/new.html.erb
+++ b/app/views/jobs/new.html.erb
@@ -43,6 +43,13 @@
     </div>
 
     <div class="control-group">
+      <%= label_tag :encoding_arguments, nil, class: 'control-label' %>
+      <div class="controls">
+        <%= text_field_tag :encoding_arguments, @job.try(:encoding_arguments), class: 'form-control' %>
+      </div>
+    </div>
+
+    <div class="control-group">
       <%= label_tag :priority, nil, class: 'control-label' %>
       <div class="controls">
         <%= text_field_tag :priority, @job.try(:priority), class: 'form-control' %>

--- a/app/views/jobs/show.html.erb
+++ b/app/views/jobs/show.html.erb
@@ -45,7 +45,7 @@
 <%= render "notifications" %>
 
 <h2>Preset parameters</h2>
-<pre><%= @job.preset.parameters rescue 'Preset not found' %></pre>
+<pre><%= "#{@job.preset.parameters} #{@job.encoding_arguments}" rescue 'Preset not found' %></pre>
 
 <% if @job.remote_job_id %>
   <h2>Delete job</h2>

--- a/db/migrate/20150720085848_add_encoding_arguments_to_jobs.rb
+++ b/db/migrate/20150720085848_add_encoding_arguments_to_jobs.rb
@@ -1,0 +1,5 @@
+class AddEncodingArgumentsToJobs < ActiveRecord::Migration
+  def change
+    add_column :jobs, :encoding_arguments, :string
+  end
+end


### PR DESCRIPTION
Added API support for appending custom encoding options with Job creation over API. Options are saved in the Job object and appended to the encoder_options argument in the Transcoder.job_to_json method.
